### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Purpose
This PR addresses the urgent request from issue #6 to add the GitHub Skills activity that was announced by the principal.

## 📝 Changes Made
- Added "GitHub Skills" activity to the activities dictionary
- Description highlights the practical coding/collaboration focus and GitHub Certifications program
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Capacity: 25 participants
- Currently no participants enrolled (empty list ready for signups)

## 🚨 Urgency
This is time-sensitive as registrations close by the end of this week per the principal's announcement. Students are eager to join this program which helps with college applications.

## ✅ Testing
- [x] Activity added to the system
- [x] Follows the same structure as existing activities
- [x] Ready for student registration

Fixes #6